### PR TITLE
Add LLM provider switch for OpenAI/HuggingFace

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,21 @@ conda activate ecommerce_agent
 
 ### 3. Set Up API Keys
 
-Create a `.env` file in your project root with your OpenAI key:
+Create a `.env` file in your project root with credentials for your chosen provider.
+
+For **OpenAI**:
 
 ```
 OPENAI_API_KEY=sk-xxxxxx
+LLM_PROVIDER=openai
+```
+
+For **Hugging Face**:
+
+```
+HUGGINGFACE_API_TOKEN=hf-xxxxxx
+HUGGINGFACE_MODEL_NAME=EleutherAI/gpt-neo-2.7B
+LLM_PROVIDER=huggingface
 ```
 
 ---
@@ -153,6 +164,7 @@ Edit `config.py` to set:
 * Model names (vector embeddings)
 * DB and vectorstore paths
 * HuggingFace or OpenAI model config
+* `LLM_PROVIDER` to switch between OpenAI and Hugging Face
 
 ---
 
@@ -167,7 +179,7 @@ Edit `config.py` to set:
 
 ## Troubleshooting
 
-* Make sure all CSVs are in `data/` and `.env` contains your API key.
+* Make sure all CSVs are in `data/` and `.env` contains your API credentials.
 * For vectorstore/embedding errors: check internet access for model download on first run.
 * If you change DB schema or CSVs, delete `olist.db` and rerun `main.py`.
 

--- a/config.py
+++ b/config.py
@@ -19,11 +19,16 @@ DATABASE_URL = f"sqlite:///{DATABASE_FILE}"
 
 # === External API Keys ===
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+HUGGINGFACE_API_TOKEN = os.getenv("HUGGINGFACE_API_TOKEN")
+
+# Choose LLM provider: 'openai' or 'huggingface'
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai").lower()
 
 # === LLM Settings ===
 OPENAI_MODEL_NAME = os.getenv("OPENAI_MODEL_NAME", "gpt-4o-mini")
 OPENAI_TEMPERATURE = float(os.getenv("OPENAI_TEMPERATURE", "0.2"))
 OPENAI_MAX_TOKENS = int(os.getenv("OPENAI_MAX_TOKENS", "512"))
+HUGGINGFACE_MODEL_NAME = os.getenv("HUGGINGFACE_MODEL_NAME", "EleutherAI/gpt-neo-2.7B")
 
 # === Model & Embedding Settings ===
 EMBEDDING_MODEL_NAME = os.getenv("EMBEDDING_MODEL_NAME", "sentence-transformers/all-MiniLM-L6-v2")
@@ -52,8 +57,10 @@ LOG_FILE = os.getenv("LOG_FILE", "agent_interactions.log")
 
 # === Sanity checks (optional, production-safe) ===
 def sanity_check():
-    if not OPENAI_API_KEY:
+    if LLM_PROVIDER == "openai" and not OPENAI_API_KEY:
         raise RuntimeError("OPENAI_API_KEY is not set in your environment (.env)")
+    if LLM_PROVIDER == "huggingface" and not HUGGINGFACE_API_TOKEN:
+        raise RuntimeError("HUGGINGFACE_API_TOKEN is not set in your environment (.env)")
     if not os.path.isdir(DATA_FOLDER):
         print(f"Warning: DATA_FOLDER '{DATA_FOLDER}' does not exist.")
 

--- a/deploy/conda/env.yml
+++ b/deploy/conda/env.yml
@@ -19,3 +19,4 @@ dependencies:
       - python-dotenv>=1.0.1
       - typing-extensions>=4.11.0
       - sentence-transformers>=0.6.0
+      - requests>=2.31.0


### PR DESCRIPTION
## Summary
- allow selecting the model provider at runtime via new `LLM_PROVIDER` setting
- support Hugging Face Inference API in `llm.py`
- add Hugging Face settings and provider check in `config.py`
- document provider setup in README
- add `requests` dependency to environment file

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a1577ed0c8322bd898920e8cc219c