### PR TITLE
Allow rephrase_text to see original query

### DIFF
--- a/agent/workflow.py
+++ b/agent/workflow.py
@@ -122,10 +122,13 @@ def answer_node(state: AgentState) -> AgentState:
     # Take the raw tool output from ``tool_node`` and rephrase it using
     # conversation history. The history helps produce a natural follow-up.
     raw_tool_output = state.tool_output or ""
+    query = state.input
     history_with_current = state.history + [
-        AgentTurn(user=state.input, agent=raw_tool_output)
+        AgentTurn(user=query, agent=raw_tool_output)
     ]
-    rephrased = rephrase_text(raw_tool_output, history=history_with_current)
+    rephrased = rephrase_text(
+        raw_tool_output, history=history_with_current, query=query
+    )
     state.output = rephrased
     return state
 

--- a/llm/llm.py
+++ b/llm/llm.py
@@ -122,7 +122,11 @@ def classify_intent(query: str) -> str:
 
 # ---- Rephrase Utility ----
 
-def rephrase_text(text: str, history: list["AgentTurn"] | None = None) -> str:
+def rephrase_text(
+    text: str,
+    history: list["AgentTurn"] | None = None,
+    query: str | None = None,
+) -> str:
     """Use OpenAI to make text sound friendly and natural with context.
 
     Parameters
@@ -131,6 +135,8 @@ def rephrase_text(text: str, history: list["AgentTurn"] | None = None) -> str:
         Text to rephrase.
     history : list[AgentTurn], optional
         Recent conversation turns to provide context.
+    query : str, optional
+        The user's latest question for additional context.
 
     Returns
     -------
@@ -155,8 +161,14 @@ def rephrase_text(text: str, history: list["AgentTurn"] | None = None) -> str:
             messages.append({"role": "user", "content": turn.user})
             messages.append({"role": "assistant", "content": turn.agent})
 
+    if query:
+        messages.append({"role": "user", "content": f"User question: {query}"})
+
     messages.append(
-        {"role": "user", "content": f"Please rephrase the following text:\n{text}"}
+        {
+            "role": "user",
+            "content": f"Please rephrase the following text:\n{text}",
+        }
     )
 
     return openai_chat_completion(messages)


### PR DESCRIPTION
## Summary
- extend `rephrase_text` to accept the user query
- include the query when rephrasing answers in `answer_node`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883bbac3d688322b1bdf26867380ac7